### PR TITLE
Fixing response card token validation in response and tests

### DIFF
--- a/braspag/response.py
+++ b/braspag/response.py
@@ -155,8 +155,8 @@ class PagadorDictResponse(object):
 
             if transaction_items.has_key('PaymentMethod'):
                 data['payment_method'] = to_int(transaction_items.get('PaymentMethod'))
-            if transaction_items.has_key('CreditCardToken') and len(transaction_items.get('CreditCardToken')) == 2:
-                data['card_token'] = transaction_items.get('CreditCardToken')[1]
+            if transaction_items.has_key('CreditCardToken'):
+                data['card_token'] = transaction_items.get('CreditCardToken')
             
             self.transactions.append(data)
 

--- a/tests/data/cc_auth_response.xml
+++ b/tests/data/cc_auth_response.xml
@@ -44,7 +44,6 @@
             <Status>
               1
             </Status>
-            <CreditCardToken xsi:nil="true"/>
             <CreditCardToken>
               08fc9329-2c7e-4f6a-9df4-96b483346305
             </CreditCardToken>


### PR DESCRIPTION
Havia um problema no response do teste, não estava de acordo com o que realmente a braspag responde, com isso o card_token se perdia no meio do caminho, este é o fix!
